### PR TITLE
Fix fastapi versioning.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-fastapi = "^0.68.0,<1.0.0"
+fastapi = ">0.68.0"
 aiohttp = "^3"
 cryptography = "^35.0.0"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}


### PR DESCRIPTION
Handle restriction in fastapi versioning since they are pre 1.0.0 release.

The previous change was incorrect in the way python handles ^versions. I believe this should be reasonable enough without lurching things towards a breaking change.