### PR TITLE
Support Python 3.8

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
         fastapi-version: [ "0.68.0", "0.70.0", "0.71.0" ]
     steps:
       - name: Check out repository

--- a/demo_project/api/api_v1/endpoints/hello_world.py
+++ b/demo_project/api/api_v1/endpoints/hello_world.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Dict, Union
 
 from demo_project.api.dependencies import validate_is_admin_user
 from demo_project.schemas.hello_world import HelloWorldResponse
@@ -17,7 +17,7 @@ router = APIRouter()
     operation_id='helloWorld',
     dependencies=[Depends(validate_is_admin_user)],
 )
-async def world(request: Request) -> dict[str, Union[str, User]]:
+async def world(request: Request) -> Dict[str, Union[str, User]]:
     """
     Wonder who we say hello to?
     """

--- a/demo_project/api/api_v1/endpoints/hello_world_multi_auth.py
+++ b/demo_project/api/api_v1/endpoints/hello_world_multi_auth.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Dict, Union
 
 from demo_project.api.dependencies import multi_auth
 from demo_project.schemas.hello_world import TokenType
@@ -16,7 +16,7 @@ router = APIRouter()
     name='hello_world_api_key',
     operation_id='helloWorldApiKey',
 )
-async def world(request: Request, auth: Union[str, User] = Depends(multi_auth)) -> dict[str, bool]:
+async def world(request: Request, auth: Union[str, User] = Depends(multi_auth)) -> Dict[str, bool]:
     """
     Wonder how this auth is done?
     """

--- a/fastapi_azure_auth/auth.py
+++ b/fastapi_azure_auth/auth.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Awaitable, Callable, Literal, Optional
+from typing import Any, Awaitable, Callable, Dict, Literal, Optional
 
 from fastapi.exceptions import HTTPException
 from fastapi.security import OAuth2AuthorizationCodeBearer, SecurityScopes
@@ -22,7 +22,7 @@ class AzureAuthorizationCodeBearerBase(SecurityBase):
         app_client_id: str,
         auto_error: bool = True,
         tenant_id: Optional[str] = None,
-        scopes: Optional[dict[str, str]] = None,
+        scopes: Optional[Dict[str, str]] = None,
         multi_tenant: bool = False,
         validate_iss: bool = True,
         iss_callable: Optional[Callable[[str], Awaitable[str]]] = None,
@@ -189,7 +189,8 @@ class AzureAuthorizationCodeBearerBase(SecurityBase):
                         options=options,
                     )
                     # Attach the user to the request. Can be accessed through `request.state.user`
-                    user: User = User(**token | {'claims': token, 'access_token': access_token})
+                    user_info = {'claims': token, 'access_token': access_token}
+                    user: User = User(**token, **user_info)
                     request.state.user = user
                     return user
             except JWTClaimsError as error:
@@ -219,7 +220,7 @@ class SingleTenantAzureAuthorizationCodeBearer(AzureAuthorizationCodeBearerBase)
         app_client_id: str,
         tenant_id: str,
         auto_error: bool = True,
-        scopes: Optional[dict[str, str]] = None,
+        scopes: Optional[Dict[str, str]] = None,
         token_version: Literal[1, 2] = 2,
         openid_config_use_app_id: bool = False,
         openapi_authorization_url: Optional[str] = None,
@@ -275,7 +276,7 @@ class MultiTenantAzureAuthorizationCodeBearer(AzureAuthorizationCodeBearerBase):
         self,
         app_client_id: str,
         auto_error: bool = True,
-        scopes: Optional[dict[str, str]] = None,
+        scopes: Optional[Dict[str, str]] = None,
         validate_iss: bool = True,
         iss_callable: Optional[Callable[[str], Awaitable[str]]] = None,
         openid_config_use_app_id: bool = False,

--- a/fastapi_azure_auth/auth.py
+++ b/fastapi_azure_auth/auth.py
@@ -189,8 +189,7 @@ class AzureAuthorizationCodeBearerBase(SecurityBase):
                         options=options,
                     )
                     # Attach the user to the request. Can be accessed through `request.state.user`
-                    user_info = {'claims': token, 'access_token': access_token}
-                    user: User = User(**token, **user_info)
+                    user: User = User(**{**token, 'claims': token, 'access_token': access_token})
                     request.state.user = user
                     return user
             except JWTClaimsError as error:

--- a/fastapi_azure_auth/openid_config.py
+++ b/fastapi_azure_auth/openid_config.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from cryptography.hazmat.primitives.asymmetric.types import PUBLIC_KEY_TYPES as KeyTypes
 from fastapi import HTTPException, status
@@ -90,7 +90,7 @@ class OpenIdConfig:
             jwks_response.raise_for_status()
             self._load_keys(jwks_response.json()['keys'])
 
-    def _load_keys(self, keys: list[dict[str, Any]]) -> None:
+    def _load_keys(self, keys: List[Dict[str, Any]]) -> None:
         """
         Create certificates based on signing keys and store them
         """

--- a/fastapi_azure_auth/user.py
+++ b/fastapi_azure_auth/user.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 class User(BaseModel):
     aud: str = Field(..., description='Audience')
     tid: str = Field(..., description='Tenant ID')
-    roles: list[str] = Field(default=[], description='Roles (Groups) the user has for this app')
-    claims: dict[Any, Any] = Field(..., description='The entire decoded token')
+    roles: List[str] = Field(default=[], description='Roles (Groups) the user has for this app')
+    claims: Dict[Any, Any] = Field(..., description='The entire decoded token')
     scp: Optional[str] = Field(default=None, description='Scope')
     name: Optional[str] = Field(default=None, description='Name')
     access_token: str = Field(..., description='The access_token. Can be used for fetching the Graph API')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-azure-auth"
-version = "3.3.0"  # Remember to change in __init__.py as well
+version = "3.4.0"  # Remember to change in __init__.py as well
 description = "Easy and secure implementation of Azure AD for your FastAPI APIs"
 authors = ["Jonas Krüger Svensson <jonas.svensson@intility.no>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 fastapi = ">0.68.0"
 cryptography = ">35.0.0"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}


### PR DESCRIPTION
Following is the summary of changes done -

1. Using type hints from typing library instead of built-in type hints [introduced in python 3.9](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections).

2. Using older way to concatenate 2 dictionaries instead of [newer one](https://docs.python.org/3/whatsnew/3.9.html#dictionary-merge-update-operators).

Example of older way to concatenate 2 dictionaries -> dmerged = {**d1,**d2}, here d1 and d2 are 2 dictionaries, merged into 1 as dmerged


Close #74 