### PR TITLE
Add sub and oid field to user model

### DIFF
--- a/fastapi_azure_auth/user.py
+++ b/fastapi_azure_auth/user.py
@@ -12,3 +12,5 @@ class User(BaseModel):
     name: Optional[str] = Field(default=None, description='Name')
     access_token: str = Field(..., description='The access_token. Can be used for fetching the Graph API')
     is_guest: bool = Field(False, description='The user is a guest user in the tenant')
+    sub: str = Field(..., description='Principal associated with the token.')
+    oid: str = Field(..., description='Immutable identifier for the requestor')

--- a/tests/multi_tenant/test_multi_tenant.py
+++ b/tests/multi_tenant/test_multi_tenant.py
@@ -65,6 +65,8 @@ async def test_normal_user(multi_tenant_app, mock_openid_and_keys, freezer):
                 'roles': ['AdminUser'],
                 'scp': 'user_impersonation',
                 'tid': 'intility_tenant_id',
+                'oid': '22222222-2222-2222-2222-222222222222',
+                'sub': 'some long val',
             },
         }
 

--- a/tests/multi_tenant_b2c/test_multi_tenant.py
+++ b/tests/multi_tenant_b2c/test_multi_tenant.py
@@ -61,6 +61,8 @@ async def test_normal_user(multi_tenant_app, mock_openid_and_keys, freezer):
                 'roles': ['AdminUser'],
                 'scp': 'user_impersonation',
                 'tid': 'intility_tenant_id',
+                'oid': '22222222-2222-2222-2222-222222222222',
+                'sub': 'some long val',
             },
         }
 

--- a/tests/single_tenant/test_single_tenant_v1_v2_tokens.py
+++ b/tests/single_tenant/test_single_tenant_v1_v2_tokens.py
@@ -66,6 +66,8 @@ async def test_normal_user(single_tenant_app, mock_openid_and_keys_v1_v2, freeze
                 'tid': 'intility_tenant_id',
                 'access_token': access_token,
                 'name': 'Jonas Krüger Svensson / Intility AS',
+                'oid': '22222222-2222-2222-2222-222222222222',
+                'sub': 'some long val',
             },
         }
     elif test_version == 2:
@@ -106,6 +108,8 @@ async def test_normal_user(single_tenant_app, mock_openid_and_keys_v1_v2, freeze
                 'roles': ['AdminUser'],
                 'scp': 'user_impersonation',
                 'tid': 'intility_tenant_id',
+                'oid': '22222222-2222-2222-2222-222222222222',
+                'sub': 'some long val',
             },
         }
 

--- a/tests/test_guest_user.py
+++ b/tests/test_guest_user.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pytest
 
 from fastapi_azure_auth.utils import is_guest
@@ -75,5 +77,5 @@ from fastapi_azure_auth.utils import is_guest
         'acct tenant member',
     ],
 )
-def test_guest_user(claims: dict[str, str], expected: bool):
+def test_guest_user(claims: Dict[str, str], expected: bool):
     assert is_guest(claims=claims) == expected

--- a/tests/test_openapi_scheme.py
+++ b/tests/test_openapi_scheme.py
@@ -52,6 +52,11 @@ openapi_schema = {
                         'type': 'boolean',
                     },
                     'name': {'description': 'Name', 'title': 'Name', 'type': 'string'},
+                    'oid': {
+                        'description': 'Immutable ' 'identifier ' 'for ' 'the ' 'requestor',
+                        'title': 'Oid',
+                        'type': 'string',
+                    },
                     'roles': {
                         'default': [],
                         'description': 'Roles (Groups) the user has for this app',
@@ -60,9 +65,14 @@ openapi_schema = {
                         'type': 'array',
                     },
                     'scp': {'description': 'Scope', 'title': 'Scp', 'type': 'string'},
+                    'sub': {
+                        'description': 'Principal ' 'associated ' 'with ' 'the ' 'token.',
+                        'title': 'Sub',
+                        'type': 'string',
+                    },
                     'tid': {'description': 'Tenant ID', 'title': 'Tid', 'type': 'string'},
                 },
-                'required': ['aud', 'claims', 'access_token'],
+                'required': ['aud', 'claims', 'access_token', 'sub', 'oid'],
                 'title': 'User',
                 'type': 'object',
             },


### PR DESCRIPTION
I've added  the oid and sub field to the user model and tweaked the test
accordingly.

I find that adding those to two field makes it more straightforward to use the
token for of user-based authorization.
