### PR TITLE
fix: make tid and oid optional to allow User validation in B2C

### DIFF
--- a/fastapi_azure_auth/user.py
+++ b/fastapi_azure_auth/user.py
@@ -65,12 +65,12 @@ class Claims(BaseModel):
         ...,
         description='The principal associated with the token.',
     )
-    oid: str = Field(
-        ...,
+    oid: Optional[str] = Field(
+        default=None,
         description='The immutable identifier for the requestor, which is the verified identity of the user or service principal',
     )
-    tid: str = Field(
-        ...,
+    tid: Optional[str] = Field(
+        default=None,
         description='Represents the tenant that the user is signing in to',
     )
     uti: Optional[str] = Field(

--- a/tests/test_openapi_scheme.py
+++ b/tests/test_openapi_scheme.py
@@ -173,12 +173,12 @@ openapi_schema = {
                         'description': 'The principal associated with the token.',
                     },
                     'oid': {
-                        'type': 'string',
+                        'anyOf': [{'type': 'string'}, {'type': 'null'}],
                         'title': 'Oid',
                         'description': 'The immutable identifier for the requestor, which is the verified identity of the user or service principal',
                     },
                     'tid': {
-                        'type': 'string',
+                        'anyOf': [{'type': 'string'}, {'type': 'null'}],
                         'title': 'Tid',
                         'description': 'Represents the tenant that the user is signing in to',
                     },
@@ -383,7 +383,7 @@ openapi_schema = {
                     },
                 },
                 'type': 'object',
-                'required': ['aud', 'iss', 'iat', 'nbf', 'exp', 'sub', 'oid', 'tid', 'ver', 'claims', 'access_token'],
+                'required': ['aud', 'iss', 'iat', 'nbf', 'exp', 'sub', 'ver', 'claims', 'access_token'],
                 'title': 'User',
             },
         },

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -92,7 +92,6 @@ def get_utc_now_as_unix_timestamp() -> int:
 def test_user_missing_optionals():
     user = User(
         aud='Dummy',
-        tid='Dummy',
         access_token='Dummy',
         claims={'oid': 'Dummy oid'},
         iss='https://dummy-platform.dummylogin.com/dummy-uid/v2.0/',
@@ -100,7 +99,6 @@ def test_user_missing_optionals():
         nbf=get_utc_now_as_unix_timestamp(),
         exp=get_utc_now_as_unix_timestamp(),
         sub='dummy-sub',
-        oid='dummy-oid',
         ver='1.0',
         scp='AccessAsUser',
     )


### PR DESCRIPTION
This PR is a continuation of PR #141 and was recreated to make the PR more straightforward. It makes `tid` and `oid` claims optional so that B2C auth works.
