### PR TITLE
move openapi-spec-validator and pydantic-settings to dev deps

### DIFF
--- a/fastapi_azure_auth/__init__.py
+++ b/fastapi_azure_auth/__init__.py
@@ -4,4 +4,4 @@ from fastapi_azure_auth.auth import (  # noqa: F401
     SingleTenantAzureAuthorizationCodeBearer as SingleTenantAzureAuthorizationCodeBearer,
 )
 
-__version__ = '4.2.0'
+__version__ = '4.2.1'

--- a/poetry.lock
+++ b/poetry.lock
@@ -2376,4 +2376,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f912de26bc1e6026b1106288be816db2893ae7b2a96703911aee7fcac9fd8b3f"
+content-hash = "862e33ab3ac6f74ec937e5263afc3ba11be46a71d1400761ec821adbe56fb22e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-azure-auth"
-version = "4.2.0"  # Remember to change in __init__.py as well
+version = "4.2.1"  # Remember to change in __init__.py as well
 description = "Easy and secure implementation of Azure AD for your FastAPI APIs"
 authors = ["Jonas Krüger Svensson <jonas.svensson@intility.no>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,6 @@ fastapi = ">0.68.0"
 cryptography = ">=40.0.1"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 httpx = ">0.18.2"
-pydantic-settings = "^2.0.2"
-openapi-spec-validator = "^0.6.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -68,6 +66,7 @@ trio = "^0.22.2"
 respx = "^0.20.1"
 ipython = "^8.2.0"
 openapi-spec-validator = "^0.6.0"
+pydantic-settings = "^2.0.2"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
I accidentally added openapi-spec-validator and pydantic-settings as main
dependency and not dev dependency. This is just a quick fix

I noticed it when I updated to the newest version in my project. Sorry for that 😁
