### PR TITLE
Python 3.9 support

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         fastapi-version: [ "0.103.2", "0.111.1"]
     steps:
       - name: Check out repository

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .idea/*
+.vscode
 env/
 demo_project/.env
 .DS_Store

--- a/fastapi_azure_auth/exceptions.py
+++ b/fastapi_azure_auth/exceptions.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from fastapi import HTTPException, WebSocketException, status
 from starlette.requests import HTTPConnection
 
@@ -10,7 +11,7 @@ class InvalidAuthHttp(HTTPException):
 
     def __init__(self, detail: str) -> None:
         super().__init__(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=detail, headers={'WWW-Authenticate': 'Bearer'}
+            status_code=status.HTTP_401_UNAUTHORIZED, detail=detail, headers={"WWW-Authenticate": "Bearer"}
         )
 
 
@@ -30,6 +31,6 @@ def InvalidAuth(detail: str, request: HTTPConnection) -> InvalidAuthHttp | Inval
     """
     Returns the correct exception based on the connection type
     """
-    if request.scope['type'] == 'http':
+    if request.scope["type"] == "http":
         return InvalidAuthHttp(detail)
     return InvalidAuthWebSocket(detail)

--- a/fastapi_azure_auth/exceptions.py
+++ b/fastapi_azure_auth/exceptions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from fastapi import HTTPException, WebSocketException, status
 from starlette.requests import HTTPConnection
 

--- a/fastapi_azure_auth/exceptions.py
+++ b/fastapi_azure_auth/exceptions.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from fastapi import HTTPException, WebSocketException, status
 from starlette.requests import HTTPConnection
 

--- a/fastapi_azure_auth/exceptions.py
+++ b/fastapi_azure_auth/exceptions.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from fastapi import HTTPException, WebSocketException, status
 from starlette.requests import HTTPConnection
 
@@ -11,7 +10,7 @@ class InvalidAuthHttp(HTTPException):
 
     def __init__(self, detail: str) -> None:
         super().__init__(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=detail, headers={"WWW-Authenticate": "Bearer"}
+            status_code=status.HTTP_401_UNAUTHORIZED, detail=detail, headers={'WWW-Authenticate': 'Bearer'}
         )
 
 
@@ -31,6 +30,6 @@ def InvalidAuth(detail: str, request: HTTPConnection) -> InvalidAuthHttp | Inval
     """
     Returns the correct exception based on the connection type
     """
-    if request.scope["type"] == "http":
+    if request.scope['type'] == 'http':
         return InvalidAuthHttp(detail)
     return InvalidAuthWebSocket(detail)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -85,7 +85,7 @@ def test_guest_user(claims: Dict[str, str], expected: bool):
 
 
 def get_utc_now_as_unix_timestamp() -> int:
-    date = datetime.datetime.now(datetime.UTC)
+    date = datetime.datetime.now(datetime.timezone.utc)
     return calendar.timegm(date.utctimetuple())
 
 


### PR DESCRIPTION
Fixes #208.

Utilizes `from __future__ import annotations` and `datetime.timezone.utc` to keep Python 3.9 supported.
The [datetime.UTC alias](https://docs.python.org/3/library/datetime.html#datetime.UTC) was added in Python 3.11, so this might have affected 3.10 as well.

Tests pass, albeit `test_http_error_old_config_found` both fail at first, but always pass on the second try.