### PR TITLE
feat: exceptions for auth errors 400, 401, 403

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,14 @@ To contribute, please follow these steps:
 1. Create an issue explaining what you'd like to fix or add. This way, we can approve and discuss the
 solution before any time is spent on developing it.
 2. Fork the upstream repository into a personal account.
-3. Install [poetry](https://python-poetry.org/), and install all dependencies using ``poetry install``
+3. Install [poetry](https://python-poetry.org/), and install all dependencies using ``poetry install --with dev``
 4. Activate the environment by running ``poetry shell``
 5. Install [pre-commit](https://pre-commit.com/) (for project linting) by running ``pre-commit install``
-6. Create a new branch for your changes, and make sure to add tests!
-7. Push the topic branch to your personal fork
-8. Run `pre-commit run --all-files` locally to ensure proper linting
-9. Create a pull request to the Intility repository with a detailed summary of your changes and what motivated the change
+6. Create a new branch for your changes.
+7. Create and run tests with full coverage by running `poetry run pytest --cov fastapi_azure_auth --cov-report=term-missing`
+8. Push the topic branch to your personal fork.
+9. Run `pre-commit run --all-files` locally to ensure proper linting.
+10. Create a pull request to the intility repository with a detailed summary of your changes and what motivated the change.
 
 If you need a more detailed walk through, please see this
 [issue comment](https://github.com/Intility/fastapi-azure-auth/issues/49#issuecomment-1056962282).

--- a/demo_project/core/config.py
+++ b/demo_project/core/config.py
@@ -13,9 +13,9 @@ class AzureActiveDirectory(BaseSettings):  # type: ignore[misc, valid-type]
     OPENAPI_CLIENT_ID: str = Field(default='')
     TENANT_ID: str = Field(default='')
     APP_CLIENT_ID: str = Field(default='')
-    AUTH_URL: AnyHttpUrl = Field(default='https://dummy.com/')
-    CONFIG_URL: AnyHttpUrl = Field(default='https://dummy.com/')
-    TOKEN_URL: AnyHttpUrl = Field(default='https://dummy.com/')
+    AUTH_URL: AnyHttpUrl = Field(default=AnyHttpUrl('https://dummy.com/'))
+    CONFIG_URL: AnyHttpUrl = Field(default=AnyHttpUrl('https://dummy.com/'))
+    TOKEN_URL: AnyHttpUrl = Field(default=AnyHttpUrl('https://dummy.com/'))
     GRAPH_SECRET: str = Field(default='')
     CLIENT_SECRET: str = Field(default='')
 

--- a/docs/docs/multi-tenant/accept_specific_tenants_only.mdx
+++ b/docs/docs/multi-tenant/accept_specific_tenants_only.mdx
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import AnyHttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from fastapi_azure_auth import MultiTenantAzureAuthorizationCodeBearer
-from fastapi_azure_auth.exceptions import InvalidAuth
+from fastapi_azure_auth.exceptions import Unauthorized
 
 
 class Settings(BaseSettings):
@@ -56,7 +56,7 @@ async def check_if_valid_tenant(tid: str) -> str:
     try:
         return tid_to_iss_mapping[tid]
     except KeyError:
-        raise InvalidAuth('Tenant not allowed')
+        raise Unauthorized('Tenant not allowed')
 
 azure_scheme = MultiTenantAzureAuthorizationCodeBearer(
     app_client_id=settings.APP_CLIENT_ID,
@@ -86,7 +86,7 @@ if __name__ == '__main__':
 ```
 
 We're first creating an `async function`, which takes a `tid` as an argument, and returns the tenant ID's `iss` if it's a valid tenant.
-If it's not a valid tenant, it has to raise an `InvalidAuth()` exception.
+If it's not a valid tenant, it has to raise an `Unauthorized()` exception.
 
 ## More sophisticated callable
 If you want to cache these results in memory, you can do so by creating a more sophisticated callable:
@@ -103,7 +103,7 @@ class IssuerFetcher:
     async def __call__(self, tid: str) -> str:
         """
         Check if memory cache needs to be updated or not, and then returns an issuer for a given tenant
-        :raises InvalidAuth when it's not a valid tenant
+        :raises Unauthorized when it's not a valid tenant
         """
         refresh_time = datetime.now() - timedelta(hours=1)
         if not self._config_timestamp or self._config_timestamp < refresh_time:
@@ -117,7 +117,7 @@ class IssuerFetcher:
             return self.tid_to_iss[tid]
         except Exception as error:
             log.exception('`iss` not found for `tid` %s. Error %s', tid, error)
-            raise InvalidAuth('You must be an Intility customer to access this resource')
+            raise Unauthorized('You must be an Intility customer to access this resource')
 
 
 issuer_fetcher = IssuerFetcher()

--- a/docs/docs/usage-and-faq/guest_users.mdx
+++ b/docs/docs/usage-and-faq/guest_users.mdx
@@ -39,7 +39,7 @@ would like to lock down specific endpoints.
 
 ```python title="security.py"
 from fastapi import Depends
-from fastapi_azure_auth.exceptions import InvalidAuth
+from fastapi_azure_auth.exceptions import Unauthorized
 from fastapi_azure_auth.user import User
 
 async def deny_guest_users(user: User = Depends(azure_scheme)) -> None:
@@ -47,7 +47,7 @@ async def deny_guest_users(user: User = Depends(azure_scheme)) -> None:
     Deny guest users
     """
     if user.is_guest:
-        raise InvalidAuth('Guest user not allowed')
+        raise Unauthorized('Guest user not allowed')
 ```
 
 
@@ -57,7 +57,7 @@ Alternatively, after [FastAPI 0.95.0](https://github.com/tiangolo/fastapi/releas
 ```python title="security.py"
 from typing import Annotated
 from fastapi import Depends
-from fastapi_azure_auth.exceptions import InvalidAuth
+from fastapi_azure_auth.exceptions import Unauthorized
 from fastapi_azure_auth.user import User
 
 async def deny_guest_users(user: User = Depends(azure_scheme)) -> None:
@@ -65,7 +65,7 @@ async def deny_guest_users(user: User = Depends(azure_scheme)) -> None:
     Deny guest users
     """
     if user.is_guest:
-        raise InvalidAuth('Guest user not allowed')
+        raise Unauthorized('Guest user not allowed')
 
 NonGuestUser = Annotated[User, Depends(deny_guest_users)]
 ```

--- a/docs/docs/usage-and-faq/locking_down_on_roles.mdx
+++ b/docs/docs/usage-and-faq/locking_down_on_roles.mdx
@@ -30,7 +30,7 @@ You can lock down on roles by creating your own wrapper dependency:
 
 ```python title="dependencies.py"
 from fastapi import Depends
-from fastapi_azure_auth.exceptions import InvalidAuth
+from fastapi_azure_auth.exceptions import Unauthorized
 from fastapi_azure_auth.user import User
 
 async def validate_is_admin_user(user: User = Depends(azure_scheme)) -> None:
@@ -39,7 +39,7 @@ async def validate_is_admin_user(user: User = Depends(azure_scheme)) -> None:
     Raises a 401 authentication error if not.
     """
     if 'AdminUser' not in user.roles:
-        raise InvalidAuth('User is not an AdminUser')
+        raise Unauthorized('User is not an AdminUser')
 ```
 
 and then use this dependency over `azure_scheme`.
@@ -51,7 +51,7 @@ Alternatively, after [FastAPI 0.95.0](https://github.com/tiangolo/fastapi/releas
 ```python title="security.py"
 from typing import Annotated
 from fastapi import Depends
-from fastapi_azure_auth.exceptions import InvalidAuth
+from fastapi_azure_auth.exceptions import Unauthorized
 from fastapi_azure_auth.user import User
 
 async def validate_is_admin_user(user: User = Depends(azure_scheme)) -> None:
@@ -60,7 +60,7 @@ async def validate_is_admin_user(user: User = Depends(azure_scheme)) -> None:
     Raises a 401 authentication error if not.
     """
     if 'AdminUser' not in user.roles:
-        raise InvalidAuth('User is not an AdminUser')
+        raise Unauthorized('User is not an AdminUser')
 
 AdminUser = Annotated[User, Depends(validate_is_admin_user)]
 ```

--- a/fastapi_azure_auth/auth.py
+++ b/fastapi_azure_auth/auth.py
@@ -21,6 +21,8 @@ from fastapi_azure_auth.exceptions import (
     Forbidden,
     ForbiddenHttp,
     ForbiddenWebSocket,
+    InvalidAuthHttp,
+    InvalidAuthWebSocket,
     InvalidRequest,
     InvalidRequestHttp,
     Unauthorized,
@@ -234,6 +236,8 @@ class AzureAuthorizationCodeBearerBase(SecurityBase):
             log.warning('Unable to verify token. No signing keys found')
             raise Unauthorized(detail='Unable to verify token, no signing keys found', request=request)
         except (
+            InvalidAuthHttp,
+            InvalidAuthWebSocket,
             InvalidRequestHttp,
             UnauthorizedHttp,
             UnauthorizedWebSocket,

--- a/fastapi_azure_auth/exceptions.py
+++ b/fastapi_azure_auth/exceptions.py
@@ -62,6 +62,40 @@ class ForbiddenWebSocket(WebSocketException):
         )
 
 
+#  --- start backwards-compatible code ---
+def InvalidAuth(detail: str, request: HTTPConnection) -> UnauthorizedHttp | UnauthorizedWebSocket:
+    """
+    Legacy factory function that maps to Unauthorized for backwards compatibility.
+    Returns the correct exception based on the connection type.
+    TODO: Remove in v6.0.0
+    """
+    if request.scope['type'] == 'http':
+        # Convert the legacy format to new format
+        return UnauthorizedHttp(detail)
+    return UnauthorizedWebSocket(detail)
+
+
+class InvalidAuthHttp(UnauthorizedHttp):
+    """Legacy HTTP exception class that maps to UnauthorizedHttp
+    TODO: Remove in v6.0.0
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+
+
+class InvalidAuthWebSocket(UnauthorizedWebSocket):
+    """Legacy WebSocket exception class that maps to UnauthorizedWebSocket
+    TODO: Remove in v6.0.0
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+
+
+#  --- end backwards-compatible code ---
+
+
 def InvalidRequest(detail: str, request: HTTPConnection) -> InvalidRequestHttp | InvalidRequestWebSocket:
     """Factory function for invalid request exceptions (HTTP only, as request validation happens pre-connection)"""
     if request.scope['type'] == 'http':

--- a/fastapi_azure_auth/exceptions.py
+++ b/fastapi_azure_auth/exceptions.py
@@ -4,33 +4,80 @@ from fastapi import HTTPException, WebSocketException, status
 from starlette.requests import HTTPConnection
 
 
-class InvalidAuthHttp(HTTPException):
-    """
-    Exception raised when the user is not authorized over HTTP
-    """
+class InvalidRequestHttp(HTTPException):
+    """HTTP exception for malformed/invalid requests"""
 
     def __init__(self, detail: str) -> None:
         super().__init__(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=detail, headers={'WWW-Authenticate': 'Bearer'}
+            status_code=status.HTTP_400_BAD_REQUEST, detail={"error": "invalid_request", "message": detail}
         )
 
 
-class InvalidAuthWebSocket(WebSocketException):
-    """
-    Exception raised when the user is not authorized over WebSockets
-    """
+class InvalidRequestWebSocket(WebSocketException):
+    """WebSocket exception for malformed/invalid requests"""
 
     def __init__(self, detail: str) -> None:
         super().__init__(
-            code=status.WS_1008_POLICY_VIOLATION,
-            reason=detail,
+            code=status.WS_1008_POLICY_VIOLATION, reason=str({"error": "invalid_request", "message": detail})
         )
 
 
-def InvalidAuth(detail: str, request: HTTPConnection) -> InvalidAuthHttp | InvalidAuthWebSocket:
-    """
-    Returns the correct exception based on the connection type
-    """
+class UnauthorizedHttp(HTTPException):
+    """HTTP exception for authentication failures"""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"error": "invalid_token", "message": detail},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+class UnauthorizedWebSocket(WebSocketException):
+    """WebSocket exception for authentication failures"""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(
+            code=status.WS_1008_POLICY_VIOLATION, reason=str({"error": "invalid_token", "message": detail})
+        )
+
+
+class ForbiddenHttp(HTTPException):
+    """HTTP exception for insufficient permissions"""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "insufficient_scope", "message": detail},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+class ForbiddenWebSocket(WebSocketException):
+    """WebSocket exception for insufficient permissions"""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(
+            code=status.WS_1008_POLICY_VIOLATION, reason=str({"error": "insufficient_scope", "message": detail})
+        )
+
+
+def InvalidRequest(detail: str, request: HTTPConnection) -> InvalidRequestHttp | InvalidRequestWebSocket:
+    """Factory function for invalid request exceptions (HTTP only, as request validation happens pre-connection)"""
     if request.scope['type'] == 'http':
-        return InvalidAuthHttp(detail)
-    return InvalidAuthWebSocket(detail)
+        return InvalidRequestHttp(detail)
+    return InvalidRequestWebSocket(detail)
+
+
+def Unauthorized(detail: str, request: HTTPConnection) -> UnauthorizedHttp | UnauthorizedWebSocket:
+    """Factory function for unauthorized exceptions"""
+    if request.scope["type"] == "http":
+        return UnauthorizedHttp(detail)
+    return UnauthorizedWebSocket(detail)
+
+
+def Forbidden(detail: str, request: HTTPConnection) -> ForbiddenHttp | ForbiddenWebSocket:
+    """Factory function for forbidden exceptions"""
+    if request.scope["type"] == "http":
+        return ForbiddenHttp(detail)
+    return ForbiddenWebSocket(detail)

--- a/tests/multi_tenant/multi_auth/test_auto_error.py
+++ b/tests/multi_tenant/multi_auth/test_auto_error.py
@@ -12,6 +12,7 @@ async def test_normal_azure_user_valid_token(multi_tenant_app, mock_openid_and_k
     ) as ac:
         response = await ac.get('api/v1/hello-multi-auth')
         assert response.json() == {'api_key': False, 'azure_auth': True}
+        assert response.status_code == 200
 
 
 @pytest.mark.anyio
@@ -21,6 +22,7 @@ async def test_api_key_valid_key(multi_tenant_app, mock_openid_and_keys):
     ) as ac:
         response = await ac.get('api/v1/hello-multi-auth')
         assert response.json() == {'api_key': True, 'azure_auth': False}
+        assert response.status_code == 200
 
 
 @pytest.mark.anyio
@@ -30,7 +32,10 @@ async def test_normal_azure_user_but_invalid_token(multi_tenant_app, mock_openid
         transport=ASGITransport(app=app), base_url='http://test', headers={'Authorization': 'Bearer ' + access_token}
     ) as ac:
         response = await ac.get('api/v1/hello-multi-auth')
-        assert response.json() == {'detail': 'You must either provide a valid bearer token or API key'}
+        assert response.json() == {
+            'detail': {'error': 'invalid_token', 'message': 'You must either provide a valid bearer token or API key'}
+        }
+        assert response.status_code == 401
 
 
 @pytest.mark.anyio
@@ -39,4 +44,7 @@ async def test_api_key_but_invalid_key(multi_tenant_app, mock_openid_and_keys):
         transport=ASGITransport(app=app), base_url='http://test', headers={'TEST-API-KEY': 'JonasIsNotCool'}
     ) as ac:
         response = await ac.get('api/v1/hello-multi-auth')
-        assert response.json() == {'detail': 'You must either provide a valid bearer token or API key'}
+        assert response.json() == {
+            'detail': {'error': 'invalid_token', 'message': 'You must either provide a valid bearer token or API key'}
+        }
+        assert response.status_code == 401

--- a/tests/multi_tenant/test_websocket.py
+++ b/tests/multi_tenant/test_websocket.py
@@ -1,3 +1,4 @@
+import json
 from typing import Annotated
 
 import pytest
@@ -20,7 +21,7 @@ from tests.utils import (
 
 from fastapi_azure_auth import MultiTenantAzureAuthorizationCodeBearer
 from fastapi_azure_auth.auth import AzureAuthorizationCodeBearerBase
-from fastapi_azure_auth.exceptions import InvalidAuthWebSocket
+from fastapi_azure_auth.exceptions import ForbiddenWebSocket, UnauthorizedWebSocket
 from fastapi_azure_auth.openid_config import OpenIdConfig
 from fastapi_azure_auth.user import User
 
@@ -31,7 +32,7 @@ async def validate_is_admin_user(user: User = Depends(azure_scheme)) -> User:
     Raises a 401 authentication error if not.
     """
     if 'AdminUser' not in user.roles:
-        raise InvalidAuthWebSocket('User is not an AdminUser')
+        raise ForbiddenWebSocket('User is not an AdminUser')
     return user
 
 
@@ -73,13 +74,16 @@ async def test_no_keys_to_decode_with(multi_tenant_app, mock_openid_and_empty_ke
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token()}):
             pass
-    assert error.value.reason == 'Unable to verify token, no signing keys found'
+    assert error.value.reason == str(
+        {'error': 'invalid_token', 'message': 'Unable to verify token, no signing keys found'}
+    )
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
 async def test_iss_callable_raise_error(mock_openid_and_keys):
     async def issuer_fetcher(tid):
-        raise InvalidAuthWebSocket(f'Tenant {tid} not a valid tenant')
+        raise UnauthorizedWebSocket(f'Tenant {tid} not a valid tenant')
 
     azure_scheme_overrides = generate_azure_scheme_multi_tenant_object(issuer_fetcher)
 
@@ -87,7 +91,10 @@ async def test_iss_callable_raise_error(mock_openid_and_keys):
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token()}):
             pass
-    assert error.value.reason == 'Tenant intility_tenant_id not a valid tenant'
+    assert error.value.reason == str(
+        {'error': 'invalid_token', 'message': 'Tenant intility_tenant_id not a valid tenant'}
+    )
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -112,7 +119,8 @@ async def test_normal_user_rejected(multi_tenant_app, mock_openid_and_keys):
             "/ws/admin", headers={'Authorization': 'Bearer ' + build_access_token_normal_user()}
         ):
             pass
-    assert error.value.reason == 'User is not an AdminUser'
+    assert error.value.reason == str({'error': 'insufficient_scope', 'message': 'User is not an AdminUser'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -120,7 +128,8 @@ async def test_guest_user_rejected(multi_tenant_app, mock_openid_and_keys):
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token_guest_user()}):
             pass
-    assert error.value.reason == 'Guest users not allowed'
+    assert error.value.reason == str({'error': 'insufficient_scope', 'message': 'Guest users not allowed'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -130,7 +139,8 @@ async def test_invalid_token_claims(multi_tenant_app, mock_openid_and_keys):
             "/ws", headers={'Authorization': 'Bearer ' + build_access_token_invalid_claims()}
         ):
             pass
-    assert error.value.reason == 'Token contains invalid claims'
+    assert error.value.reason == str({'error': 'invalid_token', 'message': 'Token contains invalid claims'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -140,7 +150,10 @@ async def test_no_valid_keys_for_token(multi_tenant_app, mock_openid_and_no_vali
             "/ws", headers={'Authorization': 'Bearer ' + build_access_token_invalid_claims()}
         ):
             pass
-    assert error.value.reason == 'Unable to verify token, no signing keys found'
+    assert error.value.reason == str(
+        {'error': 'invalid_token', 'message': 'Unable to verify token, no signing keys found'}
+    )
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -150,7 +163,8 @@ async def test_no_valid_scopes(multi_tenant_app, mock_openid_and_no_valid_keys):
             "/ws/scope", headers={'Authorization': 'Bearer ' + build_access_token_invalid_scopes()}
         ):
             pass
-    assert error.value.reason == 'Required scope missing'
+    assert error.value.reason == str({'error': 'insufficient_scope', 'message': 'Required scope missing'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -160,7 +174,10 @@ async def test_no_valid_invalid_formatted_scope(multi_tenant_app, mock_openid_an
             "/ws/scope", headers={'Authorization': 'Bearer ' + build_access_token_invalid_scopes(scopes=None)}
         ):
             pass
-    assert error.value.reason == 'Token contains invalid formatted scopes'
+    assert error.value.reason == str(
+        {'error': 'insufficient_scope', 'message': 'Token contains invalid formatted scopes'}
+    )
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -168,7 +185,8 @@ async def test_expired_token(multi_tenant_app, mock_openid_and_keys):
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token_expired()}):
             pass
-    assert error.value.reason == 'Token signature has expired'
+    assert error.value.reason == str({'error': 'invalid_token', 'message': 'Token signature has expired'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -177,7 +195,8 @@ async def test_evil_token(multi_tenant_app, mock_openid_and_keys):
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_evil_access_token()}):
             pass
-    assert error.value.reason == 'Unable to validate token'
+    assert error.value.reason == str({'error': 'invalid_token', 'message': 'Unable to validate token'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -186,7 +205,8 @@ async def test_malformed_token(multi_tenant_app, mock_openid_and_keys):
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer eyJhbGciOiJSUzI1NiIsInR5cI6IkpXVCJ9'}):
             pass
-    assert error.value.reason == 'Invalid token format'
+    assert error.value.reason == str({'error': 'invalid_token', 'message': 'Invalid token format'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -201,17 +221,30 @@ async def test_only_header(multi_tenant_app, mock_openid_and_keys):
             },  # {'kid': 'real thumbprint', 'x5t': 'another thumbprint'}
         ):
             pass
-    assert error.value.reason == 'Invalid token format'
+    assert error.value.reason == str({'error': 'invalid_token', 'message': 'Invalid token format'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
-async def test_exception_raised(multi_tenant_app, mock_openid_and_keys, mocker):
+async def test_exception_raised_extraction(multi_tenant_app, mock_openid_and_keys, mocker):
+    mocker.patch.object(AzureAuthorizationCodeBearerBase, 'extract_access_token', side_effect=ValueError('oops'))
+
+    with pytest.raises(WebSocketDisconnect) as error:
+        with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token()}):
+            pass
+    assert error.value.reason == str({'error': 'invalid_request', 'message': 'Unable to validate token'})
+    assert error.value.code == 1008
+
+
+@pytest.mark.anyio
+async def test_exception_raised_validation(multi_tenant_app, mock_openid_and_keys, mocker):
     mocker.patch.object(AzureAuthorizationCodeBearerBase, 'validate', side_effect=ValueError('lol'))
 
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token()}):
             pass
-    assert error.value.reason == 'Unable to process token'
+    assert error.value.reason == str({'error': 'invalid_token', 'message': 'Unable to process token'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio
@@ -221,7 +254,8 @@ async def test_exception_raised_unknown(multi_tenant_app, mock_openid_and_keys, 
     with pytest.raises(WebSocketDisconnect) as error:
         with client.websocket_connect("/ws", headers={'Authorization': 'Bearer ' + build_access_token()}):
             pass
-    assert error.value.reason == 'Unable to validate token'
+    assert error.value.reason == str({'error': 'invalid_request', 'message': 'Unable to validate token'})
+    assert error.value.code == 1008
 
 
 @pytest.mark.anyio

--- a/tests/multi_tenant_b2c/multi_auth/test_auto_error.py
+++ b/tests/multi_tenant_b2c/multi_auth/test_auto_error.py
@@ -10,6 +10,7 @@ async def test_api_key_valid_key(multi_tenant_app, mock_openid_and_keys, freezer
     ) as ac:
         response = await ac.get('api/v1/hello-multi-auth-b2c')
         assert response.json() == {'api_key': True, 'azure_auth': False}
+        assert response.status_code == 200
 
 
 @pytest.mark.anyio
@@ -18,4 +19,7 @@ async def test_api_key_but_invalid_key(multi_tenant_app, mock_openid_and_keys, f
         transport=ASGITransport(app=app), base_url='http://test', headers={'TEST-API-KEY': 'JonasIsNotCool'}
     ) as ac:
         response = await ac.get('api/v1/hello-multi-auth-b2c')
-        assert response.json() == {'detail': 'You must either provide a valid bearer token or API key'}
+        assert response.json() == {
+            'detail': {'error': 'invalid_token', 'message': 'You must either provide a valid bearer token or API key'}
+        }
+        assert response.status_code == 401

--- a/tests/test_exception_compat.py
+++ b/tests/test_exception_compat.py
@@ -1,0 +1,72 @@
+"""
+This module tests the exception handling and backwards compatibility of the exceptions module, introduced in
+issue https://github.com/intility/fastapi-azure-auth/issues/229.
+TODO: Remove this test module in v6.0.0
+"""
+import pytest
+from fastapi import HTTPException, WebSocketException, status
+
+from fastapi_azure_auth.exceptions import (
+    InvalidAuth,
+    InvalidAuthHttp,
+    InvalidAuthWebSocket,
+    UnauthorizedHttp,
+    UnauthorizedWebSocket,
+)
+
+
+def test_invalid_auth_backwards_compatibility():
+    """Test that InvalidAuth maps to correct exceptions and maintains format"""
+    # Mock HTTP request scope
+    http_conn = type('HTTPConnection', (), {'scope': {'type': 'http'}})()
+
+    # Mock WebSocket scope
+    ws_conn = type('HTTPConnection', (), {'scope': {'type': 'websocket'}})()
+
+    # Test HTTP path
+    http_exc = InvalidAuth("test message", http_conn)
+    assert isinstance(http_exc, UnauthorizedHttp)
+    assert isinstance(http_exc, HTTPException)
+    assert http_exc.status_code == status.HTTP_401_UNAUTHORIZED
+    assert http_exc.detail == {"error": "invalid_token", "message": "test message"}
+
+    # Test WebSocket path
+    ws_exc = InvalidAuth("test message", ws_conn)
+    assert isinstance(ws_exc, UnauthorizedWebSocket)
+    assert isinstance(ws_exc, WebSocketException)
+    assert ws_exc.code == status.WS_1008_POLICY_VIOLATION
+    assert ws_exc.reason == str({"error": "invalid_token", "message": "test message"})
+
+
+def test_legacy_exception_catching():
+    """Test that old exception catching patterns still work"""
+    # Test HTTP exceptions
+    http_conn = type('HTTPConnection', (), {'scope': {'type': 'http'}})()
+
+    with pytest.raises((InvalidAuthHttp, UnauthorizedHttp)) as exc_info:
+        raise InvalidAuth("test message", http_conn)
+
+    assert isinstance(exc_info.value, UnauthorizedHttp)
+    assert exc_info.value.detail == {"error": "invalid_token", "message": "test message"}
+
+    # Test WebSocket exceptions
+    ws_conn = type('HTTPConnection', (), {'scope': {'type': 'websocket'}})()
+
+    with pytest.raises((InvalidAuthWebSocket, UnauthorizedWebSocket)) as exc_info:
+        raise InvalidAuth("test message", ws_conn)
+
+    assert isinstance(exc_info.value, UnauthorizedWebSocket)
+    assert exc_info.value.reason == str({"error": "invalid_token", "message": "test message"})
+
+
+def test_new_exceptions_can_be_caught_as_legacy():
+    """Test that new exceptions can be caught with legacy catch blocks"""
+    with pytest.raises((InvalidAuthHttp, UnauthorizedHttp)) as exc_info:
+        raise UnauthorizedHttp("test message")
+
+    assert exc_info.value.detail == {"error": "invalid_token", "message": "test message"}
+
+    with pytest.raises((InvalidAuthWebSocket, UnauthorizedWebSocket)) as exc_info:
+        raise UnauthorizedWebSocket("test message")
+
+    assert exc_info.value.reason == str({"error": "invalid_token", "message": "test message"})

--- a/tests/test_openapi_scheme.py
+++ b/tests/test_openapi_scheme.py
@@ -476,4 +476,4 @@ def test_incorrect_token(test_client):
 def test_token(test_client):
     response = test_client.get('/api/v1/hello', headers={'Authorization': 'Bearer '})
     assert response.status_code == 401, response.text
-    assert response.json() == {'detail': 'Invalid token format'}
+    assert response.json() == {'detail': {'error': 'invalid_token', 'message': 'Invalid token format'}}


### PR DESCRIPTION
related to #229 

* introduce new exceptions including a factory to assign exceptions based on `starlette.request` type (http or websocket)
* updated the contributor guide
* fixed a minor mypy issue preventing pre-commit
